### PR TITLE
Flip the correct field order on backward cursor

### DIFF
--- a/paginator/paginator.go
+++ b/paginator/paginator.go
@@ -193,7 +193,7 @@ func (p *Paginator) buildOrderSQL() string {
 	for i, rule := range p.rules {
 		order := rule.Order
 		if p.isBackward() {
-			order = p.order.flip()
+			order = order.flip()
 		}
 		orders[i] = fmt.Sprintf("%s %s", rule.SQLRepr, order)
 	}


### PR DESCRIPTION
I noticed for backward pages the global order was being used instead of the field order. 