### PR TITLE
Pagination for aggregated/joined models/queries

### DIFF
--- a/cursor/decoder.go
+++ b/cursor/decoder.go
@@ -36,7 +36,7 @@ func (d *Decoder) Decode(cursor string, model interface{}) (fields []interface{}
 	}
 	for _, key := range d.keys {
 		// key is already validated at beginning
-		f, _ := util.ReflectType(model).FieldByName(key)
+		f, _ := util.ReflectFieldByPath(model, key)
 		v := reflect.New(f.Type).Interface()
 		if err := jd.Decode(v); err != nil {
 			return nil, ErrInvalidCursor
@@ -68,7 +68,7 @@ func (d *Decoder) validate(model interface{}) error {
 		return ErrInvalidModel
 	}
 	for _, key := range d.keys {
-		if _, ok := modelType.FieldByName(key); !ok {
+		if _, ok := util.ReflectFieldByPath(model, key); !ok {
 			return ErrInvalidModel
 		}
 	}

--- a/cursor/encoder.go
+++ b/cursor/encoder.go
@@ -28,10 +28,9 @@ func (e *Encoder) Encode(model interface{}) (string, error) {
 }
 
 func (e *Encoder) marshalJSON(model interface{}) ([]byte, error) {
-	rv := util.ReflectValue(model)
 	fields := make([]interface{}, len(e.keys))
 	for i, key := range e.keys {
-		f := rv.FieldByName(key)
+		f := util.ReflectValueByPath(model, key)
 		if f == (reflect.Value{}) {
 			return nil, ErrInvalidModel
 		}

--- a/paginator/paginator.go
+++ b/paginator/paginator.go
@@ -124,16 +124,14 @@ func (p *Paginator) setup(db *gorm.DB, dest interface{}) {
 		if p.rules[i].SQLRepr == "" {
 			// if key has levels then recalculate table name regardless prev value
 			// because it can be different for different keys in an aggregated model
-			if sqlTable == "" || multiKey {
-				if multiKey {
-					subkeys := strings.Split(p.rules[i].Key, ".")
-					parentPath := strings.Join(subkeys[0:len(subkeys)-1], ".")
-					if parent, ok := util.ReflectFieldByPath(dest, parentPath); ok {
-						sqlTable = db.NewScope(reflect.New(parent.Type).Interface()).TableName()
-					}
-				} else {
-					sqlTable = db.NewScope(dest).TableName()
+			if multiKey {
+				subkeys := strings.Split(p.rules[i].Key, ".")
+				parentPath := strings.Join(subkeys[0:len(subkeys)-1], ".")
+				if parent, ok := util.ReflectFieldByPath(dest, parentPath); ok {
+					sqlTable = db.NewScope(reflect.New(parent.Type).Interface()).TableName()
 				}
+			} else if sqlTable == "" {
+				sqlTable = db.NewScope(dest).TableName()
 			}
 			sqlKey := p.parseSQLKey(dest, p.rules[i].Key)
 			p.rules[i].SQLRepr = fmt.Sprintf("%s.%s", sqlTable, sqlKey)

--- a/paginator/paginator_paginate_error_test.go
+++ b/paginator/paginator_paginate_error_test.go
@@ -1,7 +1,7 @@
 package paginator
 
 func (s *paginatorSuite) TestPaginateNoRule() {
-	var orders []order
+	var orders []TestOrder
 	_, _, err := New(&Config{
 		Rules: []Rule{},
 	}).Paginate(s.db, &orders)
@@ -9,7 +9,7 @@ func (s *paginatorSuite) TestPaginateNoRule() {
 }
 
 func (s *paginatorSuite) TestPaginateInvalidLimit() {
-	var orders []order
+	var orders []TestOrder
 	_, _, err := New(&Config{
 		Limit: -1,
 	}).Paginate(s.db, &orders)
@@ -17,7 +17,7 @@ func (s *paginatorSuite) TestPaginateInvalidLimit() {
 }
 
 func (s *paginatorSuite) TestPaginateInvalidOrder() {
-	var orders []order
+	var orders []TestOrder
 	_, _, err := New(&Config{
 		Order: "123",
 	}).Paginate(s.db, &orders)
@@ -25,7 +25,7 @@ func (s *paginatorSuite) TestPaginateInvalidOrder() {
 }
 
 func (s *paginatorSuite) TestPaginateInvalidOrderOnRules() {
-	var orders []order
+	var orders []TestOrder
 	_, _, err := New(&Config{
 		Rules: []Rule{
 			{
@@ -38,7 +38,7 @@ func (s *paginatorSuite) TestPaginateInvalidOrderOnRules() {
 }
 
 func (s *paginatorSuite) TestPaginateInvalidAfterCursor() {
-	var orders []order
+	var orders []TestOrder
 	_, _, err := New(
 		WithAfter("invalid cursor"),
 	).Paginate(s.db, &orders)
@@ -46,7 +46,7 @@ func (s *paginatorSuite) TestPaginateInvalidAfterCursor() {
 }
 
 func (s *paginatorSuite) TestPaginateInvalidBeforeCursor() {
-	var orders []order
+	var orders []TestOrder
 	_, _, err := New(
 		WithBefore("invalid cursor"),
 	).Paginate(s.db, &orders)

--- a/paginator/paginator_paginate_test.go
+++ b/paginator/paginator_paginate_test.go
@@ -12,19 +12,19 @@ func (s *paginatorSuite) TestPaginateDefaultOptions() {
 	// * Limit: 10
 	// * Order: DESC
 
-	var p1 []order
+	var p1 []TestOrder
 	_, c, _ := New().Paginate(s.db, &p1)
 	s.assertIDRange(p1, 12, 3)
 	s.assertForwardOnly(c)
 
-	var p2 []order
+	var p2 []TestOrder
 	_, c, _ = New(&Config{
 		After: *c.After,
 	}).Paginate(s.db, &p2)
 	s.assertIDRange(p2, 2, 1)
 	s.assertBackwardOnly(c)
 
-	var p3 []order
+	var p3 []TestOrder
 	_, c, _ = New(&Config{
 		Before: *c.Before,
 	}).Paginate(s.db, &p3)
@@ -37,19 +37,19 @@ func (s *paginatorSuite) TestPaginateDefaultOptions() {
 func (s *paginatorSuite) TestPaginateSlicePtrs() {
 	s.givenOrders(12)
 
-	var p1 []*order
+	var p1 []*TestOrder
 	_, c, _ := New().Paginate(s.db, &p1)
 	s.assertIDRange(p1, 12, 3)
 	s.assertForwardOnly(c)
 
-	var p2 []*order
+	var p2 []*TestOrder
 	_, c, _ = New(&Config{
 		After: *c.After,
 	}).Paginate(s.db, &p2)
 	s.assertIDRange(p2, 2, 1)
 	s.assertBackwardOnly(c)
 
-	var p3 []*order
+	var p3 []*TestOrder
 	_, c, _ = New(&Config{
 		Before: *c.Before,
 	}).Paginate(s.db, &p3)
@@ -65,7 +65,7 @@ Maybe a change in behavior for how Find works between v1/v2.
 func (s *paginatorSuite) TestPaginateNonSlice() {
 	s.givenOrders(3)
 
-	var o order
+	var o TestOrder
 	_, c, _ := New().Paginate(s.db, &o)
 	s.Equal(3, o.ID)
 	s.assertNoMore(c)
@@ -75,7 +75,7 @@ func (s *paginatorSuite) TestPaginateNonSlice() {
 func (s *paginatorSuite) TestPaginateNoMore() {
 	s.givenOrders(3)
 
-	var orders []order
+	var orders []TestOrder
 	_, c, _ := New().Paginate(s.db, &orders)
 	s.assertIDRange(orders, 3, 1)
 	s.assertNoMore(c)
@@ -83,7 +83,7 @@ func (s *paginatorSuite) TestPaginateNoMore() {
 
 func (s *paginatorSuite) TestPaginateSpecialCharacter() {
 	// ordered by Remark desc -> 2, 1, 4, 3 (":" > "," > "&" > "%")
-	s.givenOrders([]order{
+	s.givenOrders([]TestOrder{
 		{ID: 1, Remark: ptrStr("a,b,c")},
 		{ID: 2, Remark: ptrStr("a:b:c")},
 		{ID: 3, Remark: ptrStr("a%b%c")},
@@ -95,12 +95,12 @@ func (s *paginatorSuite) TestPaginateSpecialCharacter() {
 		Limit: 3,
 	}
 
-	var p1 []order
+	var p1 []TestOrder
 	_, c, _ := New(&cfg).Paginate(s.db, &p1)
 	s.assertIDs(p1, 2, 1, 4)
 	s.assertForwardOnly(c)
 
-	var p2 []order
+	var p2 []TestOrder
 	_, c, _ = New(
 		&cfg,
 		WithAfter(*c.After),
@@ -108,7 +108,7 @@ func (s *paginatorSuite) TestPaginateSpecialCharacter() {
 	s.assertIDs(p2, 3)
 	s.assertBackwardOnly(c)
 
-	var p3 []order
+	var p3 []TestOrder
 	_, c, _ = New(
 		&cfg,
 		WithBefore(*c.Before),
@@ -122,19 +122,19 @@ func (s *paginatorSuite) TestPaginateSpecialCharacter() {
 func (s *paginatorSuite) TestPaginateForwardShouldTakePrecedenceOverBackward() {
 	s.givenOrders(30)
 
-	var p1 []order
+	var p1 []TestOrder
 	_, c, _ := New().Paginate(s.db, &p1)
 	s.assertIDRange(p1, 30, 21)
 	s.assertForwardOnly(c)
 
-	var p2 []order
+	var p2 []TestOrder
 	_, c, _ = New(&Config{
 		After: *c.After,
 	}).Paginate(s.db, &p2)
 	s.assertIDRange(p2, 20, 11)
 	s.assertBothDirections(c)
 
-	var p3 []order
+	var p3 []TestOrder
 	_, c, _ = New(&Config{
 		After:  *c.After,
 		Before: *c.Before,
@@ -148,7 +148,7 @@ func (s *paginatorSuite) TestPaginateForwardShouldTakePrecedenceOverBackward() {
 func (s *paginatorSuite) TestPaginateSingleKey() {
 	now := time.Now()
 	// ordered by CreatedAt desc -> 1, 3, 2
-	s.givenOrders([]order{
+	s.givenOrders([]TestOrder{
 		{ID: 1, CreatedAt: now.Add(1 * time.Hour)},
 		{ID: 2, CreatedAt: now.Add(-1 * time.Hour)},
 		{ID: 3, CreatedAt: now},
@@ -159,12 +159,12 @@ func (s *paginatorSuite) TestPaginateSingleKey() {
 		Limit: 2,
 	}
 
-	var p1 []order
+	var p1 []TestOrder
 	_, c, _ := New(&cfg).Paginate(s.db, &p1)
 	s.assertIDs(p1, 1, 3)
 	s.assertForwardOnly(c)
 
-	var p2 []order
+	var p2 []TestOrder
 	_, c, _ = New(
 		&cfg,
 		WithAfter(*c.After),
@@ -172,7 +172,7 @@ func (s *paginatorSuite) TestPaginateSingleKey() {
 	s.assertIDs(p2, 2)
 	s.assertBackwardOnly(c)
 
-	var p3 []order
+	var p3 []TestOrder
 	_, c, _ = New(
 		&cfg,
 		WithBefore(*c.Before),
@@ -184,7 +184,7 @@ func (s *paginatorSuite) TestPaginateSingleKey() {
 func (s *paginatorSuite) TestPaginateMultipleKeys() {
 	now := time.Now()
 	// ordered by (CreatedAt desc, ID desc) -> 2, 3, 1
-	s.givenOrders([]order{
+	s.givenOrders([]TestOrder{
 		{ID: 1, CreatedAt: now},
 		{ID: 2, CreatedAt: now.Add(1 * time.Hour)},
 		{ID: 3, CreatedAt: now},
@@ -195,12 +195,12 @@ func (s *paginatorSuite) TestPaginateMultipleKeys() {
 		Limit: 2,
 	}
 
-	var p1 []order
+	var p1 []TestOrder
 	_, c, _ := New(&cfg).Paginate(s.db, &p1)
 	s.assertIDs(p1, 2, 3)
 	s.assertForwardOnly(c)
 
-	var p2 []order
+	var p2 []TestOrder
 	_, c, _ = New(
 		&cfg,
 		WithAfter(*c.After),
@@ -208,7 +208,7 @@ func (s *paginatorSuite) TestPaginateMultipleKeys() {
 	s.assertIDs(p2, 1)
 	s.assertBackwardOnly(c)
 
-	var p3 []order
+	var p3 []TestOrder
 	_, c, _ = New(
 		&cfg,
 		WithBefore(*c.Before),
@@ -218,7 +218,7 @@ func (s *paginatorSuite) TestPaginateMultipleKeys() {
 }
 
 func (s *paginatorSuite) TestPaginatePointerKey() {
-	s.givenOrders([]order{
+	s.givenOrders([]TestOrder{
 		{ID: 1, Remark: ptrStr("3")},
 		{ID: 2, Remark: ptrStr("2")},
 		{ID: 3, Remark: ptrStr("1")},
@@ -229,12 +229,12 @@ func (s *paginatorSuite) TestPaginatePointerKey() {
 		Limit: 2,
 	}
 
-	var p1 []order
+	var p1 []TestOrder
 	_, c, _ := New(&cfg).Paginate(s.db, &p1)
 	s.assertIDs(p1, 1, 2)
 	s.assertForwardOnly(c)
 
-	var p2 []order
+	var p2 []TestOrder
 	_, c, _ = New(
 		&cfg,
 		WithAfter(*c.After),
@@ -242,7 +242,7 @@ func (s *paginatorSuite) TestPaginatePointerKey() {
 	s.assertIDs(p2, 3)
 	s.assertBackwardOnly(c)
 
-	var p3 []order
+	var p3 []TestOrder
 	_, c, _ = New(
 		&cfg,
 		WithBefore(*c.Before),
@@ -255,7 +255,7 @@ func (s *paginatorSuite) TestPaginateRulesShouldTakePrecedenceOverKeys() {
 	now := time.Now()
 	// ordered by ID desc -> 2, 1
 	// ordered by CreatedAt desc -> 1, 2
-	s.givenOrders([]order{
+	s.givenOrders([]TestOrder{
 		{ID: 1, CreatedAt: now.Add(1 * time.Hour)},
 		{ID: 2, CreatedAt: now},
 	})
@@ -267,7 +267,7 @@ func (s *paginatorSuite) TestPaginateRulesShouldTakePrecedenceOverKeys() {
 		Keys: []string{"ID"},
 	}
 
-	var orders []order
+	var orders []TestOrder
 	_, _, _ = New(&cfg).Paginate(s.db, &orders)
 	s.assertIDs(orders, 1, 2)
 }
@@ -291,14 +291,14 @@ func (s *paginatorSuite) TestPaginateShouldUseGormColumnTag() {
 func (s *paginatorSuite) TestPaginateLimit() {
 	s.givenOrders(10)
 
-	var p1 []order
+	var p1 []TestOrder
 	_, c, _ := New(&Config{
 		Limit: 1,
 	}).Paginate(s.db, &p1)
 	s.Len(p1, 1)
 	s.assertForwardOnly(c)
 
-	var p2 []order
+	var p2 []TestOrder
 	_, c, _ = New(&Config{
 		Limit: 20,
 		After: *c.After,
@@ -306,7 +306,7 @@ func (s *paginatorSuite) TestPaginateLimit() {
 	s.Len(p2, 9)
 	s.assertBackwardOnly(c)
 
-	var p3 []order
+	var p3 []TestOrder
 	_, c, _ = New(&Config{
 		Limit:  100,
 		Before: *c.Before,
@@ -315,12 +315,12 @@ func (s *paginatorSuite) TestPaginateLimit() {
 	s.assertForwardOnly(c)
 }
 
-/* order */
+/* TestOrder */
 
 func (s *paginatorSuite) TestPaginateOrder() {
 	now := time.Now()
 	// ordered by (CreatedAt desc, ID desc) -> 4, 2, 3, 1
-	s.givenOrders([]order{
+	s.givenOrders([]TestOrder{
 		{ID: 1, CreatedAt: now},
 		{ID: 2, CreatedAt: now.Add(1 * time.Hour)},
 		{ID: 3, CreatedAt: now},
@@ -332,7 +332,7 @@ func (s *paginatorSuite) TestPaginateOrder() {
 		Limit: 2,
 	}
 
-	var p1 []order
+	var p1 []TestOrder
 	_, c, _ := New(
 		&cfg,
 		WithOrder(ASC),
@@ -340,7 +340,7 @@ func (s *paginatorSuite) TestPaginateOrder() {
 	s.assertIDs(p1, 1, 3)
 	s.assertForwardOnly(c)
 
-	var p2 []order
+	var p2 []TestOrder
 	_, c, _ = New(
 		&cfg,
 		WithBefore(*c.After),
@@ -349,7 +349,7 @@ func (s *paginatorSuite) TestPaginateOrder() {
 	s.assertIDs(p2, 4, 2)
 	s.assertForwardOnly(c)
 
-	var p3 []order
+	var p3 []TestOrder
 	_, c, _ = New(
 		&cfg,
 		WithBefore(*c.After),
@@ -362,7 +362,7 @@ func (s *paginatorSuite) TestPaginateOrder() {
 func (s *paginatorSuite) TestPaginateOrderByKey() {
 	now := time.Now()
 	// ordered by (CreatedAt desc, ID asc) -> 4, 2, 1, 3
-	s.givenOrders([]order{
+	s.givenOrders([]TestOrder{
 		{ID: 1, CreatedAt: now},
 		{ID: 2, CreatedAt: now.Add(1 * time.Hour)},
 		{ID: 3, CreatedAt: now},
@@ -383,12 +383,12 @@ func (s *paginatorSuite) TestPaginateOrderByKey() {
 		Order: DESC, // default order for no order rule
 	}
 
-	var p1 []order
+	var p1 []TestOrder
 	_, c, _ := New(&cfg).Paginate(s.db, &p1)
 	s.assertIDs(p1, 4, 2)
 	s.assertForwardOnly(c)
 
-	var p2 []order
+	var p2 []TestOrder
 	_, c, _ = New(
 		&cfg,
 		WithAfter(*c.After),
@@ -396,7 +396,7 @@ func (s *paginatorSuite) TestPaginateOrderByKey() {
 	s.assertIDs(p2, 1, 3)
 	s.assertBackwardOnly(c)
 
-	var p3 []order
+	var p3 []TestOrder
 	_, c, _ = New(
 		&cfg,
 		WithBefore(*c.Before),
@@ -425,12 +425,12 @@ func (s *paginatorSuite) TestPaginateJoinQuery() {
 		Limit: 3,
 	}
 
-	var p1 []item
+	var p1 []TestItem
 	_, c, _ := New(&cfg).Paginate(stmt, &p1)
 	s.assertIDRange(p1, 5, 3)
 	s.assertForwardOnly(c)
 
-	var p2 []item
+	var p2 []TestItem
 	_, c, _ = New(
 		&cfg,
 		WithAfter(*c.After),
@@ -438,7 +438,7 @@ func (s *paginatorSuite) TestPaginateJoinQuery() {
 	s.assertIDRange(p2, 2, 1)
 	s.assertBackwardOnly(c)
 
-	var p3 []item
+	var p3 []TestItem
 	_, c, _ = New(
 		&cfg,
 		WithBefore(*c.Before),
@@ -507,7 +507,7 @@ func (s *paginatorSuite) TestPaginateJoinQueryWithAlias() {
 
 func (s *paginatorSuite) TestPaginateConsistencyBetweenBuilderAndKeyOptions() {
 	now := time.Now()
-	s.givenOrders([]order{
+	s.givenOrders([]TestOrder{
 		{ID: 1, CreatedAt: now},
 		{ID: 2, CreatedAt: now},
 		{ID: 3, CreatedAt: now},
@@ -515,7 +515,7 @@ func (s *paginatorSuite) TestPaginateConsistencyBetweenBuilderAndKeyOptions() {
 		{ID: 5, CreatedAt: now},
 	})
 
-	var temp []order
+	var temp []TestOrder
 	result, c, err := New(
 		WithKeys("CreatedAt", "ID"),
 		WithLimit(3),
@@ -529,7 +529,7 @@ func (s *paginatorSuite) TestPaginateConsistencyBetweenBuilderAndKeyOptions() {
 
 	anchorCursor := *c.After
 
-	var optOrders, builderOrders []order
+	var optOrders, builderOrders []TestOrder
 	var optCursor, builderCursor Cursor
 
 	// forward - keys
@@ -583,7 +583,7 @@ func (s *paginatorSuite) TestPaginateConsistencyBetweenBuilderAndKeyOptions() {
 
 func (s *paginatorSuite) TestPaginateConsistencyBetweenBuilderAndRuleOptions() {
 	now := time.Now()
-	s.givenOrders([]order{
+	s.givenOrders([]TestOrder{
 		{ID: 1, CreatedAt: now},
 		{ID: 2, CreatedAt: now},
 		{ID: 3, CreatedAt: now},
@@ -591,7 +591,7 @@ func (s *paginatorSuite) TestPaginateConsistencyBetweenBuilderAndRuleOptions() {
 		{ID: 5, CreatedAt: now},
 	})
 
-	var temp []order
+	var temp []TestOrder
 	result, c, err := New(
 		WithKeys("CreatedAt", "ID"),
 		WithLimit(3),
@@ -605,7 +605,7 @@ func (s *paginatorSuite) TestPaginateConsistencyBetweenBuilderAndRuleOptions() {
 
 	anchorCursor := *c.After
 
-	var optOrders, builderOrders []order
+	var optOrders, builderOrders []TestOrder
 	var optCursor, builderCursor Cursor
 
 	// forward - rules

--- a/paginator/paginator_test.go
+++ b/paginator/paginator_test.go
@@ -18,18 +18,26 @@ func TestPaginator(t *testing.T) {
 
 /* models */
 
-type order struct {
+type TestOrder struct {
 	ID        int       `gorm:"primary_key"`
 	Remark    *string   `gorm:"type:varchar(30)"`
 	CreatedAt time.Time `gorm:"type:timestamp;not null"`
 }
 
-type item struct {
+func (o TestOrder) TableName() string {
+	return "orders"
+}
+
+type TestItem struct {
 	ID      int     `gorm:"primary_key"`
 	Name    string  `gorm:"type:varchar(30);not null"`
 	Remark  *string `gorm:"type:varchar(30)"`
 	OrderID int     `gorm:"type:integer;not null"`
 	Order   Order   `gorm:"foreignkey:OrderID"`
+}
+
+func (i TestItem) TableName() string {
+	return "items"
 }
 
 /* paginator suite */
@@ -47,8 +55,8 @@ func (s *paginatorSuite) SetupSuite() {
 		s.FailNow(err.Error())
 	}
 	s.db = db
-	s.db.AutoMigrate(&order{}, &item{})
-	s.db.Model(&item{}).AddForeignKey("order_id", "orders(id)", "CASCADE", "CASCADE")
+	s.db.AutoMigrate(&TestOrder{}, &TestItem{})
+	s.db.Model(&TestItem{}).AddForeignKey("order_id", "orders(id)", "CASCADE", "CASCADE")
 }
 
 /* teardown */
@@ -58,21 +66,21 @@ func (s *paginatorSuite) TearDownTest() {
 }
 
 func (s *paginatorSuite) TearDownSuite() {
-	s.db.DropTable(&item{}, &order{})
+	s.db.DropTable(&TestItem{}, &TestOrder{})
 	s.db.Close()
 }
 
 /* fixtures */
 
-func (s *paginatorSuite) givenOrders(numOrOrders interface{}) (orders []order) {
+func (s *paginatorSuite) givenOrders(numOrOrders interface{}) (orders []TestOrder) {
 	switch v := numOrOrders.(type) {
 	case int:
 		for i := 0; i < v; i++ {
-			orders = append(orders, order{
+			orders = append(orders, TestOrder{
 				CreatedAt: time.Now().Add(time.Duration(i) * time.Hour),
 			})
 		}
-	case []order:
+	case []TestOrder:
 		orders = v
 	default:
 		panic("givenOrders: numOrOrders should be number or orders")
@@ -85,16 +93,16 @@ func (s *paginatorSuite) givenOrders(numOrOrders interface{}) (orders []order) {
 	return
 }
 
-func (s *paginatorSuite) givenItems(order order, numOrItems interface{}) (items []item) {
+func (s *paginatorSuite) givenItems(order TestOrder, numOrItems interface{}) (items []TestItem) {
 	switch v := numOrItems.(type) {
 	case int:
 		for i := 0; i < v; i++ {
-			items = append(items, item{
+			items = append(items, TestItem{
 				Name:    fmt.Sprintf("item %d", i+1),
 				OrderID: order.ID,
 			})
 		}
-	case []item:
+	case []TestItem:
 		items = v
 	default:
 		panic("givenItems: numOrItems should be number or items")

--- a/paginator/rule.go
+++ b/paginator/rule.go
@@ -10,7 +10,7 @@ type Rule struct {
 }
 
 func (r *Rule) validate(dest interface{}) (err error) {
-	if _, ok := util.ReflectType(dest).FieldByName(r.Key); !ok {
+	if _, ok := util.ReflectFieldByPath(dest, r.Key); !ok {
 		return ErrInvalidModel
 	}
 	if r.Order != "" {


### PR DESCRIPTION
Added support for paginating aggregated/joined models - models that includes a few simple models and are fetched with a joined query. For example given simple models:
```go
type TestOrder struct {
   ID        int       `gorm:"primary_key"`
   CreatedAt time.Time `gorm:"type:timestamp;not null"`
}

type TestItem struct {
   ID      int     `gorm:"primary_key"`
   Name    string  `gorm:"type:varchar(30);not null"`
   OrderID int     `gorm:"type:integer;not null"`

```

aggregated model can be:
```go
type OrderAndItems struct {
   TestOrder
   TestItem
}
```

and given query like:
```go
db.Model(&OrderAndItems{}).
   Select("orders.*, items.*").
   Joins("left join items on items.order_id = orders.id")
```

now it can be paginated specifying the table for each key to order by:
```go
Config{
   Keys:  []string{"TestOrder.CreatedAt", "TestOrder.ID", "TestItem.ID"},
   Limit: 2,
}
```